### PR TITLE
board 생성 및 세부내용 보기(board의 하위 및 브로드 크럼스 포함)

### DIFF
--- a/src/main/java/com/wanted/breadcrumbs/config/MyBatisConfig.java
+++ b/src/main/java/com/wanted/breadcrumbs/config/MyBatisConfig.java
@@ -18,6 +18,11 @@ public class MyBatisConfig {
         SqlSessionFactoryBean sessionFactoryBean = new SqlSessionFactoryBean();
         sessionFactoryBean.setDataSource(dataSource);
         sessionFactoryBean.setMapperLocations(new PathMatchingResourcePatternResolver().getResources("classpath:/mapper/*.xml"));
+
+        org.apache.ibatis.session.Configuration configuration = new org.apache.ibatis.session.Configuration();
+        configuration.setMapUnderscoreToCamelCase(true);
+        sessionFactoryBean.setConfiguration(configuration);
+
         return sessionFactoryBean.getObject();
     }
 

--- a/src/main/java/com/wanted/breadcrumbs/controller/BoardController.java
+++ b/src/main/java/com/wanted/breadcrumbs/controller/BoardController.java
@@ -1,0 +1,28 @@
+package com.wanted.breadcrumbs.controller;
+
+import com.wanted.breadcrumbs.dto.BoardDetail;
+import com.wanted.breadcrumbs.entity.Board;
+import com.wanted.breadcrumbs.service.BoardService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/board")
+public class BoardController {
+    @Autowired
+    BoardService boardService;
+
+    public BoardController(BoardService boardService) {
+        this.boardService = boardService;
+    }
+    @PostMapping
+    public ResponseEntity<Board> createBoard(@RequestBody Board board) {
+        Board createdBoard = boardService.createBoard(board);
+        return new ResponseEntity<>(createdBoard, HttpStatus.CREATED);
+    }
+
+}

--- a/src/main/java/com/wanted/breadcrumbs/controller/BoardController.java
+++ b/src/main/java/com/wanted/breadcrumbs/controller/BoardController.java
@@ -25,4 +25,14 @@ public class BoardController {
         return new ResponseEntity<>(createdBoard, HttpStatus.CREATED);
     }
 
+    @GetMapping("/{boardId}")
+    public ResponseEntity<BoardDetail> getBoardWithBreadcrumbs(@PathVariable Long boardId) {
+        Board board = boardService.getBoard(boardId);
+        List<Board> childBoards = boardService.getChildBoards(boardId);
+        List<Board> breadcrumbsPath = boardService.findBreadcrumbs(board);
+
+        BoardDetail boardDetail = new BoardDetail(board, childBoards, breadcrumbsPath);
+        return new ResponseEntity<>(boardDetail, HttpStatus.OK);
+    }
+
 }

--- a/src/main/java/com/wanted/breadcrumbs/controller/BoardController.java
+++ b/src/main/java/com/wanted/breadcrumbs/controller/BoardController.java
@@ -29,8 +29,10 @@ public class BoardController {
     public ResponseEntity<BoardDetail> getBoardWithBreadcrumbs(@PathVariable Long boardId) {
         Board board = boardService.getBoard(boardId);
         List<Board> childBoards = boardService.getChildBoards(boardId);
-        List<Board> breadcrumbsPath = boardService.findBreadcrumbs(board);
-
+        // 1. DB에서 가져오기
+        List<Board> breadcrumbsPath = boardService.getBreadcrumbsPath(boardId);
+        // 2. Service 영역에서 재귀 돌리기
+        // List<Board> breadcrumbsPath = boardService.findBreadcrumbs(board);
         BoardDetail boardDetail = new BoardDetail(board, childBoards, breadcrumbsPath);
         return new ResponseEntity<>(boardDetail, HttpStatus.OK);
     }

--- a/src/main/java/com/wanted/breadcrumbs/dto/BoardDetail.java
+++ b/src/main/java/com/wanted/breadcrumbs/dto/BoardDetail.java
@@ -1,0 +1,34 @@
+package com.wanted.breadcrumbs.dto;
+
+import com.wanted.breadcrumbs.entity.Board;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class BoardDetail {
+    private String boardTitle;
+    private String boardContent;
+    private List<String> childBoardTitles;
+    private List<String> breadcrumbTitles;
+
+    public BoardDetail(Board board, List<Board> childBoards, List<Board> breadcrumbs) {
+        this.boardTitle = board.getTitle();
+        this.boardContent = board.getDescription();
+
+        this.childBoardTitles = new ArrayList<>();
+        for (Board childBoard : childBoards) {
+            this.childBoardTitles.add(childBoard.getTitle());
+        }
+
+        this.breadcrumbTitles = new ArrayList<>();
+        for (Board breadcrumb : breadcrumbs) {
+            this.breadcrumbTitles.add(breadcrumb.getTitle());
+        }
+    }
+}

--- a/src/main/java/com/wanted/breadcrumbs/entity/Board.java
+++ b/src/main/java/com/wanted/breadcrumbs/entity/Board.java
@@ -1,9 +1,8 @@
 package com.wanted.breadcrumbs.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
+
+import java.util.List;
 
 @Getter
 @AllArgsConstructor
@@ -15,5 +14,5 @@ public class Board {
     private String title;
     private String description;
     private Long parentId;
-    private Integer[] subBoardListIds;
+
 }

--- a/src/main/java/com/wanted/breadcrumbs/mapper/BoardMapper.java
+++ b/src/main/java/com/wanted/breadcrumbs/mapper/BoardMapper.java
@@ -12,4 +12,6 @@ public interface BoardMapper {
     // 다른 필요한 메소드들 추가 가능
     List<Board> getBreadcrumbsPath(Long boardId);
     List<Board> getChildBoards(Long parentId);
+
+
 }

--- a/src/main/java/com/wanted/breadcrumbs/mapper/BoardMapper.java
+++ b/src/main/java/com/wanted/breadcrumbs/mapper/BoardMapper.java
@@ -10,4 +10,6 @@ public interface BoardMapper {
     void insertBoard(Board board);
     Board getBoardById(Long id);
     // 다른 필요한 메소드들 추가 가능
+    List<Board> getBreadcrumbsPath(Long boardId);
+    List<Board> getChildBoards(Long parentId);
 }

--- a/src/main/java/com/wanted/breadcrumbs/mapper/BoardMapper.java
+++ b/src/main/java/com/wanted/breadcrumbs/mapper/BoardMapper.java
@@ -2,11 +2,12 @@ package com.wanted.breadcrumbs.mapper;
 
 import com.wanted.breadcrumbs.entity.Board;
 
+import java.util.List;
+
 
 public interface BoardMapper {
 
     void insertBoard(Board board);
-
     Board getBoardById(Long id);
     // 다른 필요한 메소드들 추가 가능
 }

--- a/src/main/java/com/wanted/breadcrumbs/service/BoardService.java
+++ b/src/main/java/com/wanted/breadcrumbs/service/BoardService.java
@@ -27,6 +27,11 @@ public class BoardService {
     public Board getBoard(Long boardId) {
         return boardMapper.getBoardById(boardId);
     }
+    public List<Board> getBreadcrumbsPath(Long boardId) {
+        List<Board> breadcrumbsPath = boardMapper.getBreadcrumbsPath(boardId);
+
+        return breadcrumbsPath;
+    }
 
     public List<Board> findBreadcrumbs(Board currentBoard) {
         List<Board> breadcrumbs = new ArrayList<>();

--- a/src/main/java/com/wanted/breadcrumbs/service/BoardService.java
+++ b/src/main/java/com/wanted/breadcrumbs/service/BoardService.java
@@ -24,4 +24,37 @@ public class BoardService {
         return board;
     }
 
+    public Board getBoard(Long boardId) {
+        return boardMapper.getBoardById(boardId);
+    }
+
+    public List<Board> findBreadcrumbs(Board currentBoard) {
+        List<Board> breadcrumbs = new ArrayList<>();
+        breadcrumbs.add(currentBoard);
+        System.out.println(currentBoard.getDescription());
+
+        while (currentBoard.getParentId() != null && currentBoard.getId() != currentBoard.getParentId()) {
+            Board parentBoard = boardMapper.getBoardById(currentBoard.getParentId());
+            System.out.println(currentBoard.getParentId());
+            if (parentBoard == null) {
+                break;
+            }
+            breadcrumbs.add(parentBoard);
+            currentBoard = parentBoard;
+        }
+
+        Collections.reverse(breadcrumbs);
+
+        return breadcrumbs;
+    }
+    public List<Board> getChildBoards(Long parentId) {
+        List<Board> childBoards = boardMapper.getChildBoards(parentId);
+        if (childBoards == null) {
+            return Collections.emptyList();
+        }
+
+        return childBoards;
+    }
+
+
 }

--- a/src/main/java/com/wanted/breadcrumbs/service/BoardService.java
+++ b/src/main/java/com/wanted/breadcrumbs/service/BoardService.java
@@ -1,0 +1,27 @@
+package com.wanted.breadcrumbs.service;
+
+import com.wanted.breadcrumbs.entity.Board;
+import com.wanted.breadcrumbs.mapper.BoardMapper;
+import org.mybatis.spring.SqlSessionTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+@Service
+public class BoardService {
+    private final BoardMapper boardMapper;
+
+    @Autowired
+    public BoardService(SqlSessionTemplate sqlSessionTemplate) {
+        this.boardMapper = sqlSessionTemplate.getMapper(BoardMapper.class);
+    }
+
+    public Board createBoard(Board board) {
+        boardMapper.insertBoard(board);
+        return board;
+    }
+
+}

--- a/src/main/resources/mapper/BoardMapper.xml
+++ b/src/main/resources/mapper/BoardMapper.xml
@@ -1,13 +1,38 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.wanted.breadcrumbs.mapper.BoardMapper">
+
   <insert id="insertBoard" parameterType="com.wanted.breadcrumbs.entity.Board">
-    INSERT INTO board (title, description, parent_id, sub_board_list_ids)
-    VALUES (#{title}, #{description}, #{parentId}, #{subBoardListIds, typeHandler=org.apache.ibatis.type.ArrayTypeHandler})
+    INSERT INTO board (title, content, parent_id)
+    VALUES (#{title}, #{content}, #{parentId})
   </insert>
 
-  <select id="getBoardById" parameterType="java.lang.Long" resultType="com.wanted.breadcrumbs.entity.Board">
-    SELECT * FROM board WHERE id = #{id}
+  <select id="getBoardById" parameterType="Long" resultType="com.wanted.breadcrumbs.entity.Board">
+    SELECT id, title, content, parent_id FROM board WHERE id = #{id}
   </select>
+
+  <select id="findParentBoard" resultType="com.wanted.breadcrumbs.entity.Board">
+    SELECT * FROM board WHERE id = #{parentId}
+  </select>
+
+  <select id="getChildBoards" parameterType="Long" resultType="com.wanted.breadcrumbs.entity.Board">
+    SELECT * FROM board WHERE parent_id = #{parentId}
+  </select>
+
+  <select id="getBreadcrumbsPath" resultType="com.wanted.breadcrumbs.entity.Board">
+    WITH RECURSIVE cte(id, title, content, parent_id, depth) AS (
+    SELECT id, title, content, parent_id, 0 AS depth
+    FROM board
+    WHERE id = 5
+    UNION ALL
+    SELECT b.id, b.title, b.content, b.parent_id, cte.depth + 1
+    FROM board b
+    INNER JOIN cte ON b.id = cte.parent_id
+    )
+    SELECT id, title, content, parent_id
+    FROM cte
+    ORDER BY id ASC
+  </select>
+
 
 </mapper>


### PR DESCRIPTION
### 구현한 내용

- /board 엔드포인트에 GET 요청시 게시판 생성 엔드포인트 구현
- /board/{id} POST요청 시 board 세부내용 보는 엔드포인트 구현
- 하위 페이지는 현재페이지를 parent_id를 가지는 컬럼을 조회하여 구현
- 브로드크럼스 조회시 service 영역에서 재귀 호출 -> xml에서 cte를 이용하는 방법으로 변경


**mapper**
~~~xml
<select id="getBreadcrumbsPath" resultType="com.wanted.breadcrumbs.entity.Board">
    WITH RECURSIVE cte(id, title, content, parent_id, depth) AS (
    SELECT id, title, content, parent_id, 0 AS depth
    FROM board
    WHERE id = 5
    UNION ALL
    SELECT b.id, b.title, b.content, b.parent_id, cte.depth + 1
    FROM board b
    INNER JOIN cte ON b.id = cte.parent_id
    )
    SELECT id, title, content, parent_id
    FROM cte
    ORDER BY id ASC
  </select>
~~~
조회하고싶은 페이지의 컬럼을 depth == 0으로 두고, board 테이블을 복사하여 depth를 1씩 추가하여 재귀를 돌리며 합침
이렇게 정리된 cte테이블에서 id를 오름차순으로 정렬하여 브로드크럼스 호출
